### PR TITLE
Add Scarf Pixel to Airflow Summit

### DIFF
--- a/themes/airflowsummit/layouts/partials/header.html
+++ b/themes/airflowsummit/layouts/partials/header.html
@@ -42,5 +42,7 @@
       </ul>
     </div>
   </nav>
+  <!--  Airflow Telemetry  -->
+  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=bc607596-1ead-4c41-88d4-6a51a70eb618" />
 </header>
 <!-- Navigation End -->


### PR DESCRIPTION
Similar to https://github.com/apache/superset/pull/25065 and https://github.com/apache/airflow/pull/39533 to get Telemtry Data. More detail in https://docs.scarf.sh/web-traffic/

All of this data will be available to Airflow PMC members, and reported periodically in things like Town Hall & newsletters to know where we should organize meetups.

Discussion thread: https://lists.apache.org/thread/7f6qyr8w2n8w34g63s7ybhzphgt8h43m
Vote thread: https://lists.apache.org/thread/h1x2glvnd42rbj2q2rgpfo3pjhmpt307