### PR TITLE
Fix line breaks for Gen AI session description

### DIFF
--- a/content/sessions/2024/91-gen-ai-using-airflow-3-a-vision-for-airflow-rags.md
+++ b/content/sessions/2024/91-gen-ai-using-airflow-3-a-vision-for-airflow-rags.md
@@ -24,20 +24,10 @@ This talk goes into details about a vision to enhance Apache Airflow to more int
  
  
  
- - Support for unstructured data sources such as Text, but also 
+ - Support for unstructured data sources such as Text, but also extending to Image, Audio, Video, and Custom sensor data
  
-  extending to Image, Audio, Video, and Custom sensor data
+ - LLM model invocation, including both external model services through APIs and local models using container invocation. 
  
- - LLM model invocation, including both external model services 
+ - Automatic Index Refreshing with a focus on unstructured data lifecycle management to avoid cumbersome and expensive index creation on Vector databases
  
-  through APIs and local models using container invocation. 
- 
- - Automatic Index Refreshing with a focus on unstructured data 
- 
-  lifecycle management to avoid cumbersome and expensive 
- 
-  index creation on Vector databases
- 
- - Templates for hallucination reduction via testing and scoping 
- 
-  strategies
+ - Templates for hallucination reduction via testing and scoping strategies


### PR DESCRIPTION
This is how it is displayed currently, it fixes it
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/2943bed2-1e90-4f28-bf9c-915dfd920de3">
